### PR TITLE
Add a Material3 based theme proposal

### DIFF
--- a/lib/business_logic/models/dictionary_history.dart
+++ b/lib/business_logic/models/dictionary_history.dart
@@ -17,13 +17,17 @@ class DictionaryHistory {
   DictionaryHistory copyWith({
     String? word,
     DateTime? dateTime,
+    String? context,
+    String? bookId,
+    int? page,
   }) {
     return DictionaryHistory(
-        word: word ?? this.word,
-        dateTime: dateTime ?? this.dateTime,
-        bookId: bookId ?? this.bookId,
-        page: page ?? this.page,
-        context: context ?? this.context);
+      word: word ?? this.word,
+      dateTime: dateTime ?? this.dateTime,
+      bookId: bookId ?? this.bookId,
+      page: page ?? this.page,
+      context: context ?? this.context,
+    );
   }
 
   Map<String, dynamic> toMap() {

--- a/lib/business_logic/models/list_item.dart
+++ b/lib/business_logic/models/list_item.dart
@@ -20,15 +20,14 @@ class CategoryItem implements ListItem {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-        child: Text(
-            PaliScript.getScriptOf(
-                script: context.read<ScriptLanguageProvider>().currentScript,
-                romanText: category.name),
-            style: TextStyle(
-                fontSize: Prefs.uiFontSize + 4,
-                fontWeight: FontWeight.bold,
-                color: Theme.of(context).primaryColor)));
+    return Text(
+        PaliScript.getScriptOf(
+            script: context.read<ScriptLanguageProvider>().currentScript,
+            romanText: category.name),
+        style: TextStyle(
+            fontSize: Prefs.uiFontSize + 4,
+            fontWeight: FontWeight.bold,
+            color: Theme.of(context).primaryColor));
   }
 }
 
@@ -40,7 +39,7 @@ class BookItem implements ListItem {
 
   @override
   Widget build(BuildContext context) => Card(
-        elevation: 2,
+        shadowColor: Colors.transparent,
         child: Padding(
           padding: const EdgeInsets.all(10.0),
           child: ColoredText(

--- a/lib/data/flex_theme_data.dart
+++ b/lib/data/flex_theme_data.dart
@@ -1,32 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
-
-FlexSchemeColor myFlexColorLight = FlexSchemeColor.from(
-  primary: Colors.brown,
-);
-
-/*
-const FlexSchemeColor myScheme1Light = FlexSchemeColor(
-  primary: Color(0xFF4E0028),
-  primaryVariant: Color(0xFF320019),
-  secondary: Color(0xFF003419),
-  secondaryVariant: Color(0xFF002411),
-  // The built in schemes use their secondary variant color as their
-  // custom app bar color, it could of course be any color, but for consistency
-  // we will do the same in this custom FlexSchemeColor.
-  appBarColor: Color(0xFF002411),
-);
-
-const FlexSchemeColor myScheme1Dark = FlexSchemeColor(
-  primary: Color(0xFF9E7389),
-  primaryVariant: Color(0xFF775C69),
-  secondary: Color(0xFF738F81),
-  secondaryVariant: Color(0xFF5C7267),
-  // Again we use same secondaryVariant color as optional custom app bar color.
-  appBarColor: Color(0xFF5C7267),
-);
-
-*/
+import 'package:flutter/material.dart';
 
 class MyThemes {
   static const orange2Name = 'Orange 2';
@@ -180,6 +153,11 @@ final List<FlexSchemeData> myFlexSchemes = <FlexSchemeData>[
       tertiaryContainer: Color(0xFF535393),
     ),
   ),
+
+  // @rydmike: DESIGN TIP: You cannot use same primary secondary colors in
+  // light and dark mode, it creates themes with poor contrast in light or dark
+  // mode depending on selected colors. The colors needs to be tunes for
+  // each mode to look good.
   const FlexSchemeData(
     name: 'Pa-Auk Burgundy',
     description: 'Paauka Color Burgundy',

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -73,7 +73,7 @@ class RouteGenerator {
         screen = const DownloadView();
         break;
       case '/text-converter-view':
-        screen = TextConverterView();
+        screen = const TextConverterView();
         break;
     }
     return MaterialPageRoute(builder: (BuildContext context) => screen);

--- a/lib/services/provider/theme_change_notifier.dart
+++ b/lib/services/provider/theme_change_notifier.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/material.dart';
 import 'package:flex_color_scheme/flex_color_scheme.dart';
-import 'package:tipitaka_pali/services/prefs.dart';
+import 'package:flutter/material.dart';
 import 'package:tipitaka_pali/data/flex_theme_data.dart';
+import 'package:tipitaka_pali/services/prefs.dart';
 import 'package:tipitaka_pali/services/provider/script_language_provider.dart';
 
 import '../../utils/font_utils.dart';
@@ -76,106 +76,108 @@ class ThemeChangeNotifier extends ChangeNotifier {
     notifyListeners();
   }
 
-  //returns // flexschemedata
-  get darkTheme => FlexColorScheme.dark(
-        // As scheme colors we use the one from our list
-        // pointed to by the current themeIndex.
+  // Returns dark ThemeData made by FlexColorScheme
+  ThemeData get darkTheme => FlexThemeData.dark(
         colors: myFlexSchemes[Prefs.themeIndex].dark,
-        // Medium strength surface branding used in this example.
         surfaceMode: FlexSurfaceMode.highScaffoldLowSurface,
-        visualDensity: FlexColorScheme.comfortablePlatformDensity,
-        appBarStyle: FlexAppBarStyle.custom,
-        textTheme: _textTheme,
-        useMaterial3: false,
-        blendLevel: 5,
-        appBarOpacity: 0.66,
-      ).toTheme;
-
-  ThemeData get themeData {
-    if (Prefs.useM3) {
-      return FlexColorScheme.light(
-        // As scheme colors we use the one from our list
-        // pointed to by the current themeIndex.
-        useMaterial3: true,
-        colors: myFlexSchemes[Prefs.themeIndex].light,
-        // Medium strength surface branding used in this example.
-        surfaceMode: FlexSurfaceMode.highScaffoldLowSurface,
-        visualDensity: FlexColorScheme.comfortablePlatformDensity,
-        textTheme: _textTheme,
-      ).toTheme;
-    } else {
-      return
-          //ThemeData get themeData=>  myFlexSchemes[Prefs.themeIndex].light().toTheme();
-          FlexThemeData.light(
-        colors: myFlexSchemes[Prefs.themeIndex].light,
-        appBarStyle: FlexAppBarStyle.primary,
-        appBarElevation: 4.0,
-        bottomAppBarElevation: 8.0,
+        blendLevel: 2,
         tabBarStyle: FlexTabBarStyle.forAppBar,
-        subThemesData: const FlexSubThemesData(
-          interactionEffects: false,
-          tintedDisabledControls: false,
+        transparentStatusBar: true,
+        subThemesData: FlexSubThemesData(
+          appBarScrolledUnderElevation: Prefs.useM3 ? 6 : 0,
+          blendOnLevel: 15,
+          useTextTheme: true,
+          useM2StyleDividerInM3: true,
+          elevatedButtonSchemeColor: SchemeColor.onPrimaryContainer,
+          elevatedButtonSecondarySchemeColor: SchemeColor.primaryContainer,
+          inputDecoratorSchemeColor: SchemeColor.primary,
+          inputDecoratorBackgroundAlpha: 28,
+          inputDecoratorRadius: 8.0,
+          inputDecoratorUnfocusedHasBorder: false,
+          fabUseShape: true,
+          fabAlwaysCircular: true,
+          fabSchemeColor: SchemeColor.secondary,
+          alignedDropdown: true,
+          useInputDecoratorThemeInDialogs: true,
+          drawerWidth: 300,
+          tabBarIndicatorSize: TabBarIndicatorSize.tab,
+          cardElevation: Prefs.useM3 ? 2 : 4,
+          interactionEffects: true,
+        ),
+        keyColors: Prefs.useM3
+            ? const FlexKeyColors(
+                useSecondary: true,
+                useTertiary: true,
+                keepPrimary: true,
+                keepSecondary: true,
+                keepTertiary: true,
+              )
+            : null,
+        tones: FlexTones.candyPop(Brightness.dark),
+        visualDensity: FlexColorScheme.comfortablePlatformDensity,
+        textTheme: _textTheme,
+        useMaterial3: Prefs.useM3,
+      ).copyWith(
+        // Custom ExpansionTileTheme that removes the extra borders.
+        expansionTileTheme: const ExpansionTileThemeData(
+          shape: Border(),
+          collapsedShape: Border(),
+        ),
+      );
+
+  // Returns light ThemeData made by FlexColorScheme
+  ThemeData get themeData => FlexThemeData.light(
+        colors: myFlexSchemes[Prefs.themeIndex].light,
+        surfaceMode: FlexSurfaceMode.highScaffoldLowSurface,
+        blendLevel: 1,
+        appBarStyle: Prefs.useM3 ? FlexAppBarStyle.surface : null,
+        tabBarStyle: FlexTabBarStyle.forAppBar,
+        transparentStatusBar: true,
+        appBarElevation: Prefs.useM3 ? 3 : 0,
+        subThemesData: FlexSubThemesData(
+          appBarScrolledUnderElevation: Prefs.useM3 ? 6 : 0,
+          blendOnLevel: 8,
           blendOnColors: false,
           useTextTheme: true,
           useM2StyleDividerInM3: true,
-          adaptiveRemoveElevationTint: FlexAdaptive.all(),
-          adaptiveElevationShadowsBack: FlexAdaptive.all(),
-          adaptiveAppBarScrollUnderOff: FlexAdaptive.all(),
-          defaultRadius: 4.0,
-          elevatedButtonSchemeColor: SchemeColor.onPrimary,
-          elevatedButtonSecondarySchemeColor: SchemeColor.primary,
-          inputDecoratorSchemeColor: SchemeColor.onSurface,
-          inputDecoratorBackgroundAlpha: 13,
-          inputDecoratorBorderSchemeColor: SchemeColor.primary,
-          inputDecoratorUnfocusedBorderIsColored: false,
+          elevatedButtonSchemeColor: SchemeColor.onPrimaryContainer,
+          elevatedButtonSecondarySchemeColor: SchemeColor.primaryContainer,
+          inputDecoratorSchemeColor: SchemeColor.primary,
+          inputDecoratorBackgroundAlpha: 23,
+          inputDecoratorRadius: 8.0,
+          inputDecoratorUnfocusedHasBorder: false,
           fabUseShape: true,
           fabAlwaysCircular: true,
-          chipSchemeColor: SchemeColor.primary,
-          chipRadius: 20.0,
-          popupMenuElevation: 8.0,
+          fabSchemeColor: SchemeColor.secondary,
           alignedDropdown: true,
-          tooltipRadius: 4,
-          dialogElevation: 24.0,
           useInputDecoratorThemeInDialogs: true,
-          datePickerHeaderBackgroundSchemeColor: SchemeColor.primary,
-          snackBarBackgroundSchemeColor: SchemeColor.inverseSurface,
-          appBarScrolledUnderElevation: 4.0,
+          drawerWidth: 300,
+          chipSelectedSchemeColor:
+              Prefs.useM3 ? SchemeColor.primaryContainer : null,
           tabBarIndicatorSize: TabBarIndicatorSize.tab,
-          tabBarIndicatorWeight: 2,
-          tabBarIndicatorTopRadius: 0,
-          tabBarDividerColor: Color(0x00000000),
-          drawerElevation: 16.0,
-          drawerWidth: 304.0,
-          bottomSheetElevation: 10.0,
-          bottomSheetModalElevation: 20.0,
-          bottomNavigationBarSelectedLabelSchemeColor: SchemeColor.primary,
-          bottomNavigationBarSelectedIconSchemeColor: SchemeColor.primary,
-          bottomNavigationBarElevation: 8.0,
-          menuElevation: 8.0,
-          menuBarRadius: 0.0,
-          menuBarElevation: 1.0,
-          navigationBarSelectedLabelSchemeColor: SchemeColor.onSurface,
-          navigationBarUnselectedLabelSchemeColor: SchemeColor.onSurface,
-          navigationBarSelectedIconSchemeColor: SchemeColor.onSurface,
-          navigationBarUnselectedIconSchemeColor: SchemeColor.onSurface,
-          navigationBarIndicatorSchemeColor: SchemeColor.secondary,
-          navigationBarBackgroundSchemeColor: SchemeColor.surfaceVariant,
-          navigationBarElevation: 0.0,
-          navigationRailSelectedLabelSchemeColor: SchemeColor.onSurface,
-          navigationRailUnselectedLabelSchemeColor: SchemeColor.onSurface,
-          navigationRailSelectedIconSchemeColor: SchemeColor.onSurface,
-          navigationRailUnselectedIconSchemeColor: SchemeColor.onSurface,
-          navigationRailIndicatorSchemeColor: SchemeColor.secondary,
+          cardElevation: Prefs.useM3 ? 2 : 4,
+          interactionEffects: true,
         ),
+        keyColors: Prefs.useM3
+            ? const FlexKeyColors(
+                useSecondary: true,
+                useTertiary: true,
+                keepPrimary: true,
+                keepSecondary: true,
+                keepTertiary: true,
+              )
+            : null,
+        tones: FlexTones.candyPop(Brightness.light),
         visualDensity: FlexColorScheme.comfortablePlatformDensity,
         textTheme: _textTheme,
-
-        useMaterial3: true,
-        // To use the Playground font, add GoogleFonts package and uncomment
-        // fontFamily: GoogleFonts.notoSans().fontFamily,
+        useMaterial3: Prefs.useM3,
+      ).copyWith(
+        // Custom ExpansionTileTheme that removes the extra borders.
+        expansionTileTheme: const ExpansionTileThemeData(
+          shape: Border(),
+          collapsedShape: Border(),
+        ),
       );
-    }
-  }
 
   TextTheme get _textTheme {
     // this was changed for getting the laos font to work in the UI section of the

--- a/lib/services/provider/user_notifier.dart
+++ b/lib/services/provider/user_notifier.dart
@@ -5,7 +5,7 @@ class UserNotifier extends ChangeNotifier {
   bool get isSignedIn => Prefs.isSignedIn;
   bool get isSignedOut => !Prefs.isSignedIn;
   String _message = "";
-  void set message(String value) {
+  set message(String value) {
     _message = value;
     notifyListeners();
   }

--- a/lib/ui/dialogs/extension_prompt_dialog.dart
+++ b/lib/ui/dialogs/extension_prompt_dialog.dart
@@ -3,22 +3,22 @@ import 'package:flutter/material.dart';
 class ExtensionPromptDialog extends StatelessWidget {
   final String message;
 
-  const ExtensionPromptDialog({required this.message});
+  const ExtensionPromptDialog({super.key, required this.message});
 
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Text("Extensions Found"),
+      title: const Text("Extensions Found"),
       content: Text(message),
       actions: [
         TextButton(
-          child: Text("Yes"),
+          child: const Text("Yes"),
           onPressed: () {
             Navigator.of(context).pop(true); // Return true to indicate install
           },
         ),
         TextButton(
-          child: Text("No"),
+          child: const Text("No"),
           onPressed: () {
             Navigator.of(context)
                 .pop(false); // Return false to indicate skip install

--- a/lib/ui/dialogs/toc_dialog.dart
+++ b/lib/ui/dialogs/toc_dialog.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:tipitaka_pali/business_logic/models/toc.dart';
 import 'package:tipitaka_pali/business_logic/models/toc_list_item.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:tipitaka_pali/services/prefs.dart';
 import 'package:tipitaka_pali/ui/dialogs/toc_dialog_view_controller.dart';
 import 'package:tipitaka_pali/ui/widgets/pali_search_field.dart';
@@ -92,7 +92,7 @@ class _TocDialogState extends State<TocDialog> {
                   }
 
                   if (tocs.isEmpty) {
-                    return Center(child: Text('not found'));
+                    return const Center(child: Text('not found'));
                   }
                   currentIndex = getIndex(widget.currentPage, tocs);
                   Future.delayed(const Duration(milliseconds: 500), () {
@@ -113,7 +113,7 @@ class _TocDialogState extends State<TocDialog> {
                           controller: autoScrollController,
                           index: index,
                           child: Card(
-                            margin: EdgeInsets.all(1),
+                            margin: const EdgeInsets.all(1),
                             elevation: .8,
                             child: ListTile(
                               minVerticalPadding: 1,

--- a/lib/ui/screens/dictionary/dictionary_page.dart
+++ b/lib/ui/screens/dictionary/dictionary_page.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
 import 'package:tipitaka_pali/services/database/database_helper.dart';
 import 'package:tipitaka_pali/services/repositories/dictionary_repo.dart';
 import 'package:tipitaka_pali/ui/widgets/get_velthuis_help_widget.dart';
+
 import '../../../business_logic/models/dictionary_history.dart';
 import '../../../services/repositories/dictionary_history_repo.dart';
 import '../../widgets/colored_text.dart';
@@ -11,7 +13,6 @@ import 'controller/dictionary_controller.dart';
 import 'widget/dict_algo_selector.dart';
 import 'widget/dict_content_view.dart';
 import 'widget/dict_search_field.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class DictionaryPage extends StatefulWidget {
   const DictionaryPage({Key? key}) : super(key: key);
@@ -40,6 +41,7 @@ class _DictionaryPageState extends State<DictionaryPage>
           onKey: (event) => _handleKeyboardEvent(event, context, dc),
 
           child: Scaffold(
+            extendBody: true,
             appBar: AppBar(
               leading: getVelthuisHelp(context),
               title: Text(AppLocalizations.of(context)!.dictionary),

--- a/lib/ui/screens/dictionary/flashcards_view.dart
+++ b/lib/ui/screens/dictionary/flashcards_view.dart
@@ -1,16 +1,18 @@
-import 'package:beautiful_soup_dart/beautiful_soup.dart';
-import 'package:file_picker/file_picker.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_speed_dial/flutter_speed_dial.dart';
-import 'package:path/path.dart' as path;
 import 'dart:io';
+
+import 'package:beautiful_soup_dart/beautiful_soup.dart';
 import 'package:csv/csv.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flash_card/flash_card.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
-import 'package:tipitaka_pali/ui/screens/dictionary/controller/dictionary_controller.dart';
-import '../../../business_logic/models/dictionary_history.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_speed_dial/flutter_speed_dial.dart';
+import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+import 'package:path/path.dart' as path;
+import 'package:tipitaka_pali/ui/screens/dictionary/controller/dictionary_controller.dart';
+
+import '../../../business_logic/models/dictionary_history.dart';
 
 class FlashCardsView extends StatelessWidget {
   final List<DictionaryHistory> cards;
@@ -185,7 +187,7 @@ class FlashCardsView extends StatelessWidget {
           itemCount: cards.length,
           itemBuilder: (context, index) {
             return FlashCard(
-              backWidget: Container(
+              backWidget: SizedBox(
                 height: 100,
                 width: 100,
                 child: Column(
@@ -271,7 +273,7 @@ class FlashCardsView extends StatelessWidget {
             height: 34.0,
             fit: BoxFit.cover,
           ),
-          backgroundColor: Color.fromARGB(255, 61, 61, 59),
+          backgroundColor: const Color.fromARGB(255, 61, 61, 59),
           label: 'Anki 3 Field Note',
           labelStyle: const TextStyle(fontSize: 18.0),
           onTap: () => _exportToAnki(context, true),

--- a/lib/ui/screens/dictionary/widget/dictionary_history_view.dart
+++ b/lib/ui/screens/dictionary/widget/dictionary_history_view.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:tipitaka_pali/business_logic/models/dictionary_history.dart';
 import 'package:tipitaka_pali/services/database/database_helper.dart';
 import 'package:tipitaka_pali/services/repositories/dictionary_repo.dart';
 import 'package:tipitaka_pali/ui/widgets/pali_text_view.dart';
 import 'package:tipitaka_pali/utils/pali_word.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 enum DictionaryHistoryOrder { time, alphabetically }
 
@@ -62,7 +62,7 @@ class _DictionaryHistoryViewState extends State<DictionaryHistoryView> {
                 histories.clear();
               });
             },
-            icon: Icon(Icons.auto_delete),
+            icon: const Icon(Icons.auto_delete),
             label: const Text("Delete All")),
         Expanded(
           child: ListView.separated(

--- a/lib/ui/screens/home/bookmark_page.dart
+++ b/lib/ui/screens/home/bookmark_page.dart
@@ -1,17 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:tipitaka_pali/services/provider/bookmark_provider.dart';
 import 'package:tipitaka_pali/services/repositories/bookmark_sync_repo.dart';
 
+import '../../../../services/provider/script_language_provider.dart';
+import '../../../../utils/pali_script.dart';
 import '../../../business_logic/models/bookmark.dart';
 import '../../../business_logic/view_models/bookmark_page_view_model.dart';
 import '../../../services/dao/bookmark_dao.dart';
 import '../../../services/database/database_helper.dart';
 import '../../dialogs/confirm_dialog.dart';
-import 'package:share_plus/share_plus.dart';
-import '../../../../services/provider/script_language_provider.dart';
-import '../../../../utils/pali_script.dart';
 
 class BookmarkPage extends StatelessWidget {
   const BookmarkPage({Key? key}) : super(key: key);
@@ -31,6 +31,9 @@ class BookmarkPage extends StatelessWidget {
       ],
       child: Scaffold(
         appBar: const BookmarkAppBar(),
+        // Rydmike proposal: Consider converting the Drawer on Home screen
+        //    to a Widget and add it also to other top level screens.
+        // drawer: Mobile.isPhone(context) ? AppDrawer(context) : null,
         body: Consumer2<BookmarkPageViewModel, BookmarkNotifier>(
           builder: (context, vm, bn, child) {
             // Assuming BookmarkNotifier has a similar bookmarks list
@@ -99,6 +102,9 @@ class BookmarkAppBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     return AppBar(
+      // Rydmike: Consider not having implicit back, as it will give idea that
+      //  user can go back, but back leads out of app in this case.
+      automaticallyImplyLeading: false,
       title: Text(AppLocalizations.of(context)!.bookmark),
       actions: [
         IconButton(

--- a/lib/ui/screens/home/dekstop_navigation_bar.dart
+++ b/lib/ui/screens/home/dekstop_navigation_bar.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
 import 'package:tipitaka_pali/data/constants.dart';
 import 'package:tipitaka_pali/providers/navigation_provider.dart';
-import 'package:provider/provider.dart';
 
 class DeskTopNavigationBar extends StatelessWidget {
   const DeskTopNavigationBar({
@@ -23,7 +23,6 @@ class DeskTopNavigationBar extends StatelessWidget {
 
     return NavigationRail(
       minWidth: navigationBarWidth,
-      indicatorColor: Theme.of(context).focusColor,
       leading: Ink.image(
         height: navigationBarWidth,
         width: navigationBarWidth,

--- a/lib/ui/screens/home/desktop_home_view.dart
+++ b/lib/ui/screens/home/desktop_home_view.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
 import 'package:tipitaka_pali/data/constants.dart';
 import 'package:tipitaka_pali/providers/navigation_provider.dart';
+import 'package:tipitaka_pali/services/prefs.dart';
 import 'package:tipitaka_pali/services/rx_prefs.dart';
 
 import '../../../data/flex_theme_data.dart';
@@ -9,8 +11,6 @@ import '../../widgets/my_vertical_divider.dart';
 import '../reader/reader_container.dart';
 import 'dekstop_navigation_bar.dart';
 import 'navigation_pane.dart';
-import 'package:provider/provider.dart';
-import 'package:tipitaka_pali/services/prefs.dart';
 
 class DesktopHomeView extends StatefulWidget {
   const DesktopHomeView({Key? key}) : super(key: key);
@@ -67,6 +67,9 @@ class _DesktopHomeViewState extends State<DesktopHomeView>
 
   @override
   Widget build(BuildContext context) {
+    // RydMike: Avoid things like this, prefer using themes correctly!
+    //   But OK sometimes needed, but rarely. Not sure why this is used in
+    //   conditional build below. Looks like some temp experiment. :)
     final isOrange2 = Prefs.themeName == MyThemes.orange2Name;
     return PreferenceBuilder<double>(
         preference: context
@@ -80,28 +83,22 @@ class _DesktopHomeViewState extends State<DesktopHomeView>
                   if (isOrange2)
                     Container(
                       decoration: const BoxDecoration(
-                        border: Border(
-                          right: BorderSide(color: Colors.grey)
-                        )
-                      ),
+                          border:
+                              Border(right: BorderSide(color: Colors.grey))),
                       child: const DeskTopNavigationBar(),
                     ),
-                  if (!isOrange2)
-                    ...[
-                      const DeskTopNavigationBar(),
-                      const MyVerticalDivider(width: 2),
-                    ],
-                  // Naviagation Pane
+                  if (!isOrange2) ...[
+                    const DeskTopNavigationBar(),
+                    const MyVerticalDivider(width: 2),
+                  ],
+                  // Navigation Pane
                   SizeTransition(
                     sizeFactor: _tween.animate(_animation),
                     axis: Axis.horizontal,
                     axisAlignment: 1,
                     child: SizedBox(
                       width: width,
-                      child:
-                      const DetailNavigationPane(navigationCount: 7),
-
-
+                      child: const DetailNavigationPane(navigationCount: 7),
                     ),
                   ),
                   // reader view

--- a/lib/ui/screens/home/home_container.dart
+++ b/lib/ui/screens/home/home_container.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flex_color_scheme/flex_color_scheme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 
 import '../../../providers/navigation_provider.dart';
@@ -11,7 +13,6 @@ import 'desktop_home_view.dart';
 import 'mobile_navigation_bar.dart';
 import 'navigation_pane.dart';
 import 'openning_books_provider.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 // enum Screen { Home, Bookmark, Recent, Search }
 
@@ -31,11 +32,17 @@ class Home extends StatelessWidget {
                   Platform.isWindows || Platform.isLinux ? true : false): () =>
               context.read<OpenningBooksProvider>().remove(),
         },
-        child: Focus(
-          autofocus: true,
-          child: Container(
-            color: Theme.of(context).appBarTheme.backgroundColor,
+        child: AnnotatedRegion<SystemUiOverlayStyle>(
+          value: FlexColorScheme.themedSystemNavigationBar(
+            context,
+            systemNavBarStyle: FlexSystemNavBarStyle.transparent,
+            useDivider: false,
+          ),
+          child: Focus(
+            autofocus: true,
             child: SafeArea(
+              top: PlatformInfo.isDesktop || Mobile.isTablet(context),
+              bottom: PlatformInfo.isDesktop || Mobile.isTablet(context),
               child: WillPopScope(
                 onWillPop: () async {
                   return await _onWillPop(context);

--- a/lib/ui/screens/home/recent_page.dart
+++ b/lib/ui/screens/home/recent_page.dart
@@ -2,14 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 
+import '../../../../services/provider/script_language_provider.dart';
+import '../../../../utils/pali_script.dart';
 import '../../../business_logic/view_models/recent_page_view_model.dart';
 import '../../../services/dao/recent_dao.dart';
 import '../../../services/database/database_helper.dart';
 import '../../../services/prefs.dart';
 import '../../../services/repositories/recent_repo.dart';
 import '../../dialogs/confirm_dialog.dart';
-import '../../../../services/provider/script_language_provider.dart';
-import '../../../../utils/pali_script.dart';
 
 class RecentPage extends StatelessWidget {
   const RecentPage({Key? key}) : super(key: key);
@@ -22,6 +22,9 @@ class RecentPage extends StatelessWidget {
         ..fetchRecents(),
       child: Scaffold(
         appBar: const RecentAppBar(),
+        // Rydmike proposal: Consider converting the Drawer on Home screen
+        //    to a Widget and add it also to other top level screens.
+        // drawer: Mobile.isPhone(context) ? AppDrawer(context) : null,
         body: Consumer<RecentPageViewModel>(builder: (context, vm, child) {
           final recents = vm.recents;
           return recents.isEmpty
@@ -33,7 +36,7 @@ class RecentPage extends StatelessWidget {
                     return ListTile(
                       dense: true,
                       contentPadding: const EdgeInsets.all(0),
-                        visualDensity:
+                      visualDensity:
                           const VisualDensity(horizontal: 0, vertical: -4),
                       title: Padding(
                           padding: const EdgeInsets.only(left: 5),
@@ -78,6 +81,9 @@ class RecentAppBar extends StatelessWidget implements PreferredSizeWidget {
   Widget build(BuildContext context) {
     return AppBar(
       title: Text(AppLocalizations.of(context)!.recent),
+      // Rydmike: Consider not having implicit back, as it will give idea that
+      //  user can go back, but back leads out of app in this case.
+      automaticallyImplyLeading: false,
       actions: [
         IconButton(
             icon: const Icon(Icons.delete),

--- a/lib/ui/screens/home/search_page/search_page.dart
+++ b/lib/ui/screens/home/search_page/search_page.dart
@@ -1,22 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
-import 'package:tipitaka_pali/ui/widgets/get_velthuis_help_widget.dart';
 import 'package:tipitaka_pali/ui/widgets/value_listenser.dart';
-import 'package:tipitaka_pali/utils/platform_info.dart';
-import '../../../../services/database/database_helper.dart';
-import '../../../../services/prefs.dart';
-import '../../../../services/repositories/search_history_repo.dart';
-import '../../../widgets/search_type_segmented_widget.dart';
-import 'search_history_view.dart';
-import 'search_suggestion_view.dart';
 
 import '../../../../business_logic/view_models/search_page_view_model.dart';
 import '../../../../inner_routes.dart';
+import '../../../../services/database/database_helper.dart';
+import '../../../../services/prefs.dart';
+import '../../../../services/repositories/search_history_repo.dart';
 import '../../../../utils/pali_script.dart';
 import '../../../../utils/pali_script_converter.dart';
 import '../../../../utils/script_detector.dart';
+import '../../../widgets/search_type_segmented_widget.dart';
 import '../widgets/search_bar.dart';
+import 'search_history_view.dart';
+import 'search_suggestion_view.dart';
 
 enum QueryMode { exact, prefix, distance, anywhere }
 
@@ -67,11 +65,20 @@ class _SearchPageState extends State<SearchPage>
           final vm = context.watch<SearchPageViewModel>();
           return Scaffold(
               appBar: AppBar(
-                // disable because of conflit with mobile search
+                // Disable because of conflict with mobile search
                 // leading: getVelthuisHelp(context),
-                automaticallyImplyLeading: Mobile.isPhone(context),
+
+                // Rydmike: Consider not having implicit back, as it will give idea that
+                //  user can go back, but back leads out of app in this case.
+                automaticallyImplyLeading: false, // Mobile.isPhone(context),
                 title: Text(AppLocalizations.of(context)!.search),
-                centerTitle: true,
+                // Rydmike info: Prefer consistent alignment on AppBar.
+                //  if default, iOs is centered, Android start by default
+                // centerTitle: true,
+
+                // Rydmike proposal: Consider converting Drawer on Home screen
+                //    to a Widget and add it also to other top level screens.
+                // drawer: Mobile.isPhone(context) ? AppDrawer(context) : null,
                 actions: [
                   FilterChip(
                       label: Text(
@@ -278,7 +285,7 @@ class _SearchPageState extends State<SearchPage>
                     children: <Widget>[
                       Text(
                           message), // Display the message from the database helper
-                      if (!isTaskCompleted) CircularProgressIndicator(),
+                      if (!isTaskCompleted) const CircularProgressIndicator(),
                     ],
                   ),
                   actions: <Widget>[

--- a/lib/ui/screens/initial_setup.dart
+++ b/lib/ui/screens/initial_setup.dart
@@ -1,18 +1,22 @@
-import 'package:flutter/material.dart';
-import 'package:im_stepper/stepper.dart';
 import 'dart:io';
+
+import 'package:flex_color_scheme/flex_color_scheme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:im_stepper/stepper.dart';
+import 'package:path/path.dart' as path;
 import 'package:provider/provider.dart';
 import 'package:tipitaka_pali/business_logic/view_models/initial_setup_service.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:tipitaka_pali/providers/initial_setup_notifier.dart';
 import 'package:tipitaka_pali/services/prefs.dart';
+import 'package:tipitaka_pali/ui/dialogs/extension_prompt_dialog.dart';
 import 'package:tipitaka_pali/ui/screens/settings/download_view.dart';
+import 'package:tipitaka_pali/ui/screens/settings/select_script_language.dart';
 import 'package:tipitaka_pali/ui/widgets/colored_text.dart';
 import 'package:tipitaka_pali/ui/widgets/select_language_widget.dart';
-import 'package:tipitaka_pali/ui/screens/settings/select_script_language.dart';
-import 'package:path/path.dart' as path;
+
 import '../dialogs/reset_dialog.dart';
-import 'package:tipitaka_pali/ui/dialogs/extension_prompt_dialog.dart';
 
 class InitialSetup extends StatelessWidget {
   final bool isUpdateMode;
@@ -27,10 +31,20 @@ class InitialSetup extends StatelessWidget {
     initialSetupService.setUp(isUpdateMode);
 
     return Material(
-      child: ChangeNotifierProvider.value(
-        value: initialSetupNotifier,
-        child: Center(
-          child: _buildHomeView(context, initialSetupNotifier),
+      // NOTE by Rydmike: Annotated region example for
+      // Android: No AppBar status scrim and no sys nav scrim.
+      child: AnnotatedRegion<SystemUiOverlayStyle>(
+        value: FlexColorScheme.themedSystemNavigationBar(
+          context,
+          noAppBar: true,
+          systemNavBarStyle: FlexSystemNavBarStyle.transparent,
+          useDivider: false,
+        ),
+        child: ChangeNotifierProvider.value(
+          value: initialSetupNotifier,
+          child: Center(
+            child: _buildHomeView(context, initialSetupNotifier),
+          ),
         ),
       ),
     );

--- a/lib/ui/screens/reader/mobile_reader_container.dart
+++ b/lib/ui/screens/reader/mobile_reader_container.dart
@@ -1,11 +1,9 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:tipitaka_pali/services/prefs.dart';
 import 'package:tipitaka_pali/ui/screens/reader/reader.dart';
 import 'package:tipitaka_pali/ui/screens/reader/widgets/openning_book_list_view.dart';
 import 'package:tipitaka_pali/ui/widgets/tab_count_icon.dart';
-import 'package:tipitaka_pali/services/prefs.dart';
 
 import '../../../business_logic/models/book.dart';
 import '../../../services/provider/script_language_provider.dart';
@@ -51,73 +49,79 @@ class _MobileReaderContainerState extends State<MobileReaderContainer> {
     return ValueListenableBuilder(
         valueListenable: bookViewModeNotifier,
         builder: (context, bookViewMode, _) {
-          return Scaffold(
-            appBar: AppBar(
-              title: openningBooks.isEmpty
-                  ? null
-                  : Text(PaliScript.getScriptOf(
-                      script:
-                          context.read<ScriptLanguageProvider>().currentScript,
-                      romanText:
-                          (openningBooks[selectedBookIndex]['book'] as Book)
-                              .name)),
-              actions: [
-                IconButton(
-                  onPressed: () {
-                    if (bookViewMode == BookViewMode.horizontal) {
-                      bookViewModeNotifier.value = BookViewMode.vertical;
-                    } else {
-                      bookViewModeNotifier.value = BookViewMode.horizontal;
-                    }
-                    // save to prefs
-                    Prefs.bookViewModeIndex = bookViewModeNotifier.value.index;
-                  },
-                  icon: bookViewMode == BookViewMode.horizontal
-                      ? const Icon(Icons.swap_horiz)
-                      : const Icon(Icons.swap_vert),
-                ),
-                TabCountIcon(
-                    count: openningBooks.length,
-                    onPressed: () async {
-                      final selectedIndex =
-                          await _openOpenningBookListView(context);
-                      if (selectedIndex != null) {
-                        context
-                            .read<OpenningBooksProvider>()
-                            .updateSelectedBookIndex(selectedIndex,
-                                forceNotify: true);
-                        setState(() {
-                          // title need to update
-                          pageController.jumpToPage(selectedIndex);
-                        });
+          return SafeArea(
+            top: false,
+            bottom: true,
+            child: Scaffold(
+              appBar: AppBar(
+                title: openningBooks.isEmpty
+                    ? null
+                    : Text(PaliScript.getScriptOf(
+                        script: context
+                            .read<ScriptLanguageProvider>()
+                            .currentScript,
+                        romanText:
+                            (openningBooks[selectedBookIndex]['book'] as Book)
+                                .name)),
+                actions: [
+                  IconButton(
+                    onPressed: () {
+                      if (bookViewMode == BookViewMode.horizontal) {
+                        bookViewModeNotifier.value = BookViewMode.vertical;
+                      } else {
+                        bookViewModeNotifier.value = BookViewMode.horizontal;
                       }
-                    })
-              ],
-            ),
-            body: openningBooks.isEmpty
-                ? const Center(child: Text('There is no more openning book'))
-                : PageView.builder(
-                    controller: pageController,
-                    physics: const NeverScrollableScrollPhysics(),
-                    itemCount: openningBooks.length,
-                    itemBuilder: (context, index) {
-                      final openedBook = openningBooks[index];
-                      final book = openedBook['book'] as Book;
-                      final pageNumber = openedBook['current_page'] as int?;
-                      final textToHighlight =
-                          openedBook['text_to_highlight'] as String?;
-                      // myLogger.i('openning book index: $index');
-                      // myLogger.i('openning book name: ${book.name}');
+                      // save to prefs
+                      Prefs.bookViewModeIndex =
+                          bookViewModeNotifier.value.index;
+                    },
+                    icon: bookViewMode == BookViewMode.horizontal
+                        ? const Icon(Icons.swap_horiz)
+                        : const Icon(Icons.swap_vert),
+                  ),
+                  TabCountIcon(
+                      count: openningBooks.length,
+                      onPressed: () async {
+                        final selectedIndex =
+                            await _openOpenningBookListView(context);
+                        if (selectedIndex != null) {
+                          context
+                              .read<OpenningBooksProvider>()
+                              .updateSelectedBookIndex(selectedIndex,
+                                  forceNotify: true);
+                          setState(() {
+                            // title need to update
+                            pageController.jumpToPage(selectedIndex);
+                          });
+                        }
+                      })
+                ],
+              ),
+              body: openningBooks.isEmpty
+                  ? const Center(child: Text('There is no more openning book'))
+                  : PageView.builder(
+                      controller: pageController,
+                      physics: const NeverScrollableScrollPhysics(),
+                      itemCount: openningBooks.length,
+                      itemBuilder: (context, index) {
+                        final openedBook = openningBooks[index];
+                        final book = openedBook['book'] as Book;
+                        final pageNumber = openedBook['current_page'] as int?;
+                        final textToHighlight =
+                            openedBook['text_to_highlight'] as String?;
+                        // myLogger.i('openning book index: $index');
+                        // myLogger.i('openning book name: ${book.name}');
 
-                      return Reader(
-                        key: Key('$index - ${book.id}'),
-                        book: book,
-                        initialPage: pageNumber,
-                        textToHighlight: textToHighlight,
-                        bookViewMode: bookViewMode,
-                        bookUuid: openedBook['uuid'],
-                      );
-                    }),
+                        return Reader(
+                          key: Key('$index - ${book.id}'),
+                          book: book,
+                          initialPage: pageNumber,
+                          textToHighlight: textToHighlight,
+                          bookViewMode: bookViewMode,
+                          bookUuid: openedBook['uuid'],
+                        );
+                      }),
+            ),
           );
         });
   }

--- a/lib/ui/screens/reader/reader.dart
+++ b/lib/ui/screens/reader/reader.dart
@@ -7,9 +7,9 @@ import 'package:share_plus/share_plus.dart';
 import 'package:slidable_bar/slidable_bar.dart';
 import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
 import 'package:tipitaka_pali/data/constants.dart';
+import 'package:tipitaka_pali/services/prefs.dart';
 import 'package:tipitaka_pali/services/provider/theme_change_notifier.dart';
 import 'package:tipitaka_pali/services/rx_prefs.dart';
-import 'package:tipitaka_pali/ui/screens/reader/intents.dart';
 import 'package:tipitaka_pali/ui/screens/reader/mobile_reader_container.dart';
 import 'package:tipitaka_pali/ui/screens/reader/widgets/search_widget.dart';
 import 'package:wtf_sliding_sheet/wtf_sliding_sheet.dart';
@@ -29,10 +29,9 @@ import '../dictionary/controller/dictionary_controller.dart';
 import '../home/openning_books_provider.dart';
 import '../home/search_page/search_page.dart';
 import 'controller/reader_view_controller.dart';
-import 'widgets/vertical_book_view.dart';
 import 'widgets/horizontal_book_view.dart';
 import 'widgets/reader_tool_bar.dart';
-import 'package:tipitaka_pali/services/prefs.dart';
+import 'widgets/vertical_book_view.dart';
 
 class Reader extends StatelessWidget {
   final Book book;
@@ -169,9 +168,11 @@ class ReaderView extends StatelessWidget implements Searchable {
                                       _onClickedWord(word, context),
                                   onSearchedInCurrentBook: (text) =>
                                       _onClickedSearchInCurrent(context, text),
-                            onSelectionChanged: (text) {
-                              Provider.of<ReaderViewController>(context, listen: false).selection = text;
-                            },
+                                  onSelectionChanged: (text) {
+                                    Provider.of<ReaderViewController>(context,
+                                            listen: false)
+                                        .selection = text;
+                                  },
                                 )
                               : HorizontalBookView(
                                   onSearchedSelectedText: (text) =>
@@ -182,7 +183,9 @@ class ReaderView extends StatelessWidget implements Searchable {
                                   onSearchedInCurrentBook: (text) =>
                                       _onClickedSearchInCurrent(context, text),
                                   onSelectionChanged: (text) {
-                                    Provider.of<ReaderViewController>(context, listen: false).selection = text;
+                                    Provider.of<ReaderViewController>(context,
+                                            listen: false)
+                                        .selection = text;
                                   },
                                 )),
                     ])),
@@ -192,7 +195,7 @@ class ReaderView extends StatelessWidget implements Searchable {
   }
 
   void _onSearchSelectedText(String text, BuildContext context) {
-    // removing puntuations etc.
+    // removing punctuations etc.
     // convert to roman if display script is not roman
     var word = PaliScript.getRomanScriptFrom(
         script: context.read<ScriptLanguageProvider>().currentScript,
@@ -213,7 +216,7 @@ class ReaderView extends StatelessWidget implements Searchable {
         MaterialPageRoute(builder: (_) => const SearchPage()),
       );
     }
-    // delay a little miliseconds to wait for SearchPage Initialization
+    // delay a little milliseconds to wait for SearchPage Initialization
 
     Future.delayed(
       const Duration(milliseconds: 50),
@@ -226,7 +229,7 @@ class ReaderView extends StatelessWidget implements Searchable {
   }
 
   Future<void> _onClickedWord(String word, BuildContext context) async {
-    // removing puntuations etc.
+    // removing punctuations etc.
     // convert to roman if display script is not roman
     word = PaliScript.getRomanScriptFrom(
         script: context.read<ScriptLanguageProvider>().currentScript,
@@ -239,7 +242,7 @@ class ReaderView extends StatelessWidget implements Searchable {
     if ((PlatformInfo.isDesktop || Mobile.isTablet(context))) {
       if (context.read<NavigationProvider>().isNavigationPaneOpened) {
         context.read<NavigationProvider>().moveToDictionaryPage();
-        // delay a little miliseconds to wait for DictionaryPage Initialation
+        // delay a little milliseconds to wait for DictionaryPage initialization
         await Future.delayed(const Duration(milliseconds: 50),
             () => globalLookupWord.value = word);
         return;

--- a/lib/ui/screens/reader/welcome_container.dart
+++ b/lib/ui/screens/reader/welcome_container.dart
@@ -94,7 +94,7 @@ Etaṃ buddhānasāsanaṃ
               future: _messageFuture,
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
-                  return CircularProgressIndicator();
+                  return const CircularProgressIndicator();
                 } else if (snapshot.hasError) {
                   return Text('Error: ${snapshot.error}');
                 } else {

--- a/lib/ui/screens/reader/widgets/reader_tool_bar.dart
+++ b/lib/ui/screens/reader/widgets/reader_tool_bar.dart
@@ -4,24 +4,24 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_speed_dial/flutter_speed_dial.dart';
 import 'package:provider/provider.dart';
 import 'package:tipitaka_pali/providers/font_provider.dart';
+import 'package:tipitaka_pali/services/prefs.dart';
 import 'package:tipitaka_pali/ui/screens/dictionary/controller/dictionary_controller.dart';
 import 'package:tipitaka_pali/ui/screens/home/openning_books_provider.dart';
 import 'package:tipitaka_pali/ui/screens/reader/widgets/mat_button.dart';
 import 'package:tipitaka_pali/utils/pali_script_converter.dart';
 import 'package:tipitaka_pali/utils/platform_info.dart';
-import 'package:tipitaka_pali/services/prefs.dart';
 
 import '../../../../app.dart';
 import '../../../../business_logic/models/book.dart';
 import '../../../../business_logic/models/paragraph_mapping.dart';
 import '../../../../business_logic/models/toc.dart';
-import '../controller/reader_view_controller.dart';
 import '../../../../routes.dart';
 import '../../../../services/provider/script_language_provider.dart';
 import '../../../../utils/pali_script.dart';
 import '../../../dialogs/goto_dialog.dart';
 import '../../../dialogs/simple_input_dialog.dart';
 import '../../../dialogs/toc_dialog.dart';
+import '../controller/reader_view_controller.dart';
 import 'book_slider.dart';
 
 class ReaderToolbar extends StatelessWidget {
@@ -483,7 +483,7 @@ class LowerRow extends StatelessWidget {
       ),
     );
     if (gotoResult != null) {
-      late final pageNumber;
+      late final int pageNumber;
       int? paragraphNumber;
       String? wordToHighlight;
       if (gotoResult.type == GotoType.page) {
@@ -528,13 +528,13 @@ class LowerRow extends StatelessWidget {
         );
       },
       pageBuilder: (context, animation, secondaryAnimation) {
+        double topPadding = MediaQuery.paddingOf(context).top;
         return Align(
           alignment: Alignment.centerRight,
           child: Material(
             type: MaterialType.transparency,
             child: Container(
-              padding:
-                  const EdgeInsets.symmetric(vertical: 8.0, horizontal: 8.0),
+              padding: EdgeInsets.fromLTRB(8, 8 + topPadding, 8, 8),
               width: MediaQuery.of(context).size.width > 600
                   ? sideSheetWidth
                   : double.infinity,
@@ -599,22 +599,22 @@ class LowerRow extends StatelessWidget {
       //shape: const CircleBorder(),
       children: [
         SpeedDialChild(
-          child: Text("Tika"),
-          backgroundColor: Colors.white,
+          child: const Text("Tika"),
+          backgroundColor: Theme.of(context).colorScheme.surfaceVariant,
 //          label: 'Tika',
           labelStyle: const TextStyle(fontSize: 18.0),
           onTap: () => _onTikaButtonClicked(context),
         ),
         SpeedDialChild(
-          child: Text("Aṭṭh"),
-          backgroundColor: Colors.white,
+          child: const Text("Aṭṭh"),
+          backgroundColor: Theme.of(context).colorScheme.surfaceVariant,
 //          label: 'Aṭṭhakathā',
           labelStyle: const TextStyle(fontSize: 18.0),
           onTap: () => _onAtthaButtonClicked(context),
         ),
         SpeedDialChild(
-          child: Text("Mula"),
-          backgroundColor: Colors.white,
+          child: const Text("Mula"),
+          backgroundColor: Theme.of(context).colorScheme.surfaceVariant,
 //          label: 'Mula',
           labelStyle: const TextStyle(fontSize: 18.0),
           onTap: () => _onMulaButtonClicked(context),

--- a/lib/ui/screens/reader/widgets/vertical_book_view.dart
+++ b/lib/ui/screens/reader/widgets/vertical_book_view.dart
@@ -15,7 +15,7 @@ import 'pali_page_widget.dart';
 import 'vertical_book_slider.dart';
 
 class VerticalBookView extends StatefulWidget {
-  VerticalBookView(
+  const VerticalBookView(
       {Key? key,
       this.onSearchedSelectedText,
       this.onSharedSelectedText,
@@ -34,7 +34,13 @@ class VerticalBookView extends StatefulWidget {
 }
 
 class _VerticalBookViewState extends State<VerticalBookView>
-    implements PageUp, PageDown, ScrollUp, ScrollDown, IncreaseFont, DecreaseFont {
+    implements
+        PageUp,
+        PageDown,
+        ScrollUp,
+        ScrollDown,
+        IncreaseFont,
+        DecreaseFont {
   late final ReaderViewController readerViewController;
   late final ItemPositionsListener itemPositionsListener;
   late final ItemScrollController itemScrollController;
@@ -67,15 +73,12 @@ class _VerticalBookViewState extends State<VerticalBookView>
 
       if (pos.length == 1) {
         target = start + pos.first.index;
-
       } else if (pos.length >= 3) {
         // When there are more than 3 pages displayed the entire content of the
         // second page is visible on the screen
         target = start + pos[1].index;
-
       } else if (pos.first.itemTrailingEdge == pos.last.itemLeadingEdge) {
         target = start + pos.first.index;
-
       } else {
         // At this point we're dealing with 2 pages
         // whichever page covers more area
@@ -83,7 +86,6 @@ class _VerticalBookViewState extends State<VerticalBookView>
             ? pos.first
             : pos.last;
         target = start + page.index;
-
       }
 
       readerViewController.onGoto(pageNumber: target);
@@ -135,8 +137,7 @@ class _VerticalBookViewState extends State<VerticalBookView>
           LogicalKeySet(LogicalKeyboardKey.arrowDown): const ScrollDownIntent(),
           LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.equal):
               const IncreaseFontIntent(),
-          LogicalKeySet(
-                  LogicalKeyboardKey.control, LogicalKeyboardKey.minus):
+          LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.minus):
               const DecreaseFontIntent(),
         },
         child: Actions(
@@ -198,7 +199,7 @@ class _VerticalBookViewState extends State<VerticalBookView>
                         itemScrollController: itemScrollController,
                         itemPositionsListener: itemPositionsListener,
                         scrollOffsetController: scrollOffsetController,
-                        scrollOffsetListener:  scrollOffsetListener,
+                        scrollOffsetListener: scrollOffsetListener,
                         itemCount: readerViewController.pages.length,
                         itemBuilder: (_, index) {
                           final PageContent pageContent =
@@ -220,17 +221,18 @@ class _VerticalBookViewState extends State<VerticalBookView>
                           );
 
                           return PaliPageWidget(
-                              pageNumber: pageContent.pageNumber!,
-                              htmlContent: htmlContent,
-                              script: script,
-                              highlightedWord:
-                                  readerViewController.textToHighlight,
-                              searchText: searchText,
-                              pageToHighlight:
-                                  readerViewController.pageToHighlight,
-                              onClick: widget.onClickedWord,
-                              book: readerViewController.book,);
-                              // bookmarks: readerViewController.bookmarks,);
+                            pageNumber: pageContent.pageNumber!,
+                            htmlContent: htmlContent,
+                            script: script,
+                            highlightedWord:
+                                readerViewController.textToHighlight,
+                            searchText: searchText,
+                            pageToHighlight:
+                                readerViewController.pageToHighlight,
+                            onClick: widget.onClickedWord,
+                            book: readerViewController.book,
+                          );
+                          // bookmarks: readerViewController.bookmarks,);
                         },
                       )),
                 ),

--- a/lib/ui/screens/settings/general_settings_view.dart
+++ b/lib/ui/screens/settings/general_settings_view.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
-
 import 'package:tipitaka_pali/services/prefs.dart';
 import 'package:tipitaka_pali/services/provider/theme_change_notifier.dart';
 import 'package:tipitaka_pali/ui/screens/settings/panel_size_setting_view.dart';
@@ -41,7 +40,6 @@ class _GeneralSettingsViewState extends State<GeneralSettingsView> {
   @override
   Widget build(BuildContext context) {
     return Card(
-      elevation: 8,
       child: ExpansionTile(
         leading: const Icon(Icons.settings),
         title: Text(AppLocalizations.of(context)!.generalSettings,

--- a/lib/ui/screens/settings/help_about.dart
+++ b/lib/ui/screens/settings/help_about.dart
@@ -1,11 +1,13 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:in_app_review/in_app_review.dart';
 import 'package:tipitaka_pali/ui/dialogs/reset_dialog.dart';
+import 'package:url_launcher/url_launcher.dart';
+
 import '../../dialogs/about_tpr_dialog.dart';
 import '../../widgets/colored_text.dart';
-import 'package:url_launcher/url_launcher.dart';
-import 'package:in_app_review/in_app_review.dart';
-import 'dart:io' show Platform;
 
 class HelpAboutView extends StatefulWidget {
   const HelpAboutView({Key? key}) : super(key: key);
@@ -28,7 +30,6 @@ class _HelpAboutViewState extends State<HelpAboutView> {
   @override
   Widget build(BuildContext context) {
     return Card(
-      elevation: 8,
       child: ExpansionTile(
         leading: const Icon(Icons.info),
         title: Text(AppLocalizations.of(context)!.helpAboutEtc,
@@ -98,7 +99,7 @@ class _HelpAboutViewState extends State<HelpAboutView> {
       padding: const EdgeInsets.only(left: 32.0),
       child: ListTile(
         leading: const Icon(Icons.video_library), // Added Icon
-        title: ColoredText("YouTube Channel"),
+        title: const ColoredText("YouTube Channel"),
         focusColor: Theme.of(context).focusColor,
         hoverColor: Theme.of(context).hoverColor,
         onTap: () => launchUrl(

--- a/lib/ui/screens/settings/script_setting_view.dart
+++ b/lib/ui/screens/settings/script_setting_view.dart
@@ -15,7 +15,6 @@ class ScriptSettingView extends StatelessWidget {
         child: Consumer<ScriptSettingController>(
           builder: (context, controller, child) {
             return Card(
-              elevation: 8,
               child: ExpansionTile(
                 leading: const Icon(Icons.font_download_outlined),
                 title: Text(AppLocalizations.of(context)!.paliScript,

--- a/lib/ui/screens/settings/settings.dart
+++ b/lib/ui/screens/settings/settings.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:provider/provider.dart';
 import 'package:tipitaka_pali/services/provider/bookmark_provider.dart';
 import 'package:tipitaka_pali/services/provider/theme_change_notifier.dart';
 import 'package:tipitaka_pali/ui/screens/settings/sync_settings.dart';
@@ -6,14 +8,10 @@ import 'package:tipitaka_pali/ui/screens/settings/tools_settings.dart';
 import 'package:tipitaka_pali/ui/widgets/select_dictionary_widget.dart';
 import 'package:tipitaka_pali/ui/widgets/select_language_widget.dart';
 import 'package:tipitaka_pali/ui/widgets/select_theme_widget.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:provider/provider.dart';
-import 'package:tipitaka_pali/data/constants.dart';
 
-import 'download_view.dart';
+import 'general_settings_view.dart';
 import 'help_about.dart';
 import 'script_setting_view.dart';
-import 'general_settings_view.dart';
 
 class SettingPage extends StatelessWidget {
   const SettingPage({Key? key}) : super(key: key);
@@ -23,15 +21,17 @@ class SettingPage extends StatelessWidget {
     final sc = ScrollController(); // for auto scroll
 
     return Scaffold(
+        extendBody: true,
         appBar: AppBar(
           title: Text(AppLocalizations.of(context)!.settings),
           actions: const [],
         ),
         body: Padding(
-          padding: const EdgeInsets.all(16.0),
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
           child: ListView(
             controller: sc, // Attach the ScrollController to ListVie
             children: <Widget>[
+              const SizedBox(height: 16),
               const DictionarySettingView(),
               const ThemeSettingView(),
               const DarkModeSettingView(),
@@ -56,7 +56,6 @@ class ThemeSettingView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      elevation: 8,
       child: ListTile(
           leading: const Icon(Icons.palette_outlined),
           title: Text(
@@ -74,29 +73,18 @@ class DarkModeSettingView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      elevation: 8,
       child: ListTile(
         leading: const Icon(Icons.brightness_2_outlined),
         trailing: ToggleButtons(
-          color: Colors.red,
           onPressed: (int index) {
             Provider.of<ThemeChangeNotifier>(context, listen: false)
                 .toggleTheme(index);
           },
           isSelected: context.read<ThemeChangeNotifier>().isSelected,
-          children: <Widget>[
-            CircleAvatar(
-              backgroundColor: Theme.of(context).highlightColor,
-              child: const Icon(Icons.article, color: Colors.white),
-            ),
-            CircleAvatar(
-              backgroundColor: Theme.of(context).highlightColor,
-              child: const Icon(Icons.article, color: Color(seypia)),
-            ),
-            CircleAvatar(
-              backgroundColor: Theme.of(context).highlightColor,
-              child: const Icon(Icons.article, color: Colors.black),
-            ),
+          children: const <Widget>[
+            Icon(Icons.wb_sunny),
+            Icon(Icons.phone_iphone),
+            Icon(Icons.bedtime),
           ],
         ),
         title: Text(
@@ -114,7 +102,6 @@ class LanguageSettingView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      elevation: 8,
       child: ListTile(
         leading: const Icon(Icons.language_outlined),
         title: Text(
@@ -133,7 +120,6 @@ class DictionarySettingView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      elevation: 8,
       child: ExpansionTile(
         leading: const Icon(Icons.sort_by_alpha_outlined),
         title: Text(AppLocalizations.of(context)!.dictionaries,

--- a/lib/ui/screens/settings/sync_settings.dart
+++ b/lib/ui/screens/settings/sync_settings.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart'; // Assuming SharedPreferences for storing user info.
 import 'package:tipitaka_pali/services/prefs.dart';
 import 'package:tipitaka_pali/services/provider/user_notifier.dart';
 import 'package:tipitaka_pali/services/repositories/fire_user_repository.dart';
+
 import '../../widgets/colored_text.dart';
 
 class SyncSettingsView extends StatefulWidget {
@@ -15,8 +14,8 @@ class SyncSettingsView extends StatefulWidget {
 }
 
 class _SyncSettingsViewState extends State<SyncSettingsView> {
-  TextEditingController _emailController = TextEditingController();
-  TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
 
   @override
   void initState() {
@@ -39,7 +38,6 @@ class _SyncSettingsViewState extends State<SyncSettingsView> {
         _passwordController.clear();
       }
       return Card(
-        elevation: 8,
         child: ExpansionTile(
           leading: const Icon(Icons.sync),
           title: Text(
@@ -60,7 +58,7 @@ class _SyncSettingsViewState extends State<SyncSettingsView> {
       padding: const EdgeInsets.only(left: 32.0),
       child: ListTile(
         leading: const Icon(Icons.refresh),
-        title: ColoredText("Sign In"), // Changed "Sign Up" to "Sign In"
+        title: const ColoredText("Sign In"), // Changed "Sign Up" to "Sign In"
         focusColor: Theme.of(context).focusColor,
         hoverColor: Theme.of(context).hoverColor,
         onTap: () {
@@ -77,7 +75,7 @@ class _SyncSettingsViewState extends State<SyncSettingsView> {
         children: [
           TextField(
             controller: _emailController,
-            decoration: InputDecoration(
+            decoration: const InputDecoration(
               labelText: 'Email',
               icon: Icon(Icons.person),
             ),
@@ -85,10 +83,10 @@ class _SyncSettingsViewState extends State<SyncSettingsView> {
               Prefs.email = value;
             },
           ),
-          SizedBox(height: 16.0),
+          const SizedBox(height: 16.0),
           TextField(
             controller: _passwordController,
-            decoration: InputDecoration(
+            decoration: const InputDecoration(
               labelText: 'Password',
               icon: Icon(Icons.lock),
             ),
@@ -97,7 +95,7 @@ class _SyncSettingsViewState extends State<SyncSettingsView> {
               Prefs.password = value;
             },
           ),
-          SizedBox(height: 16.0),
+          const SizedBox(height: 16.0),
           ElevatedButton(
             onPressed: Prefs.isSignedIn
                 ? () async {
@@ -117,7 +115,7 @@ class _SyncSettingsViewState extends State<SyncSettingsView> {
                   },
             child: Text(Prefs.isSignedIn ? 'Sign Out' : 'Sign In'),
           ),
-          SizedBox(height: 16.0),
+          const SizedBox(height: 16.0),
           (Prefs.isSignedIn)
               ? const SizedBox.shrink()
               : ElevatedButton(
@@ -127,7 +125,7 @@ class _SyncSettingsViewState extends State<SyncSettingsView> {
                     await userRepository.register(
                         _emailController.text, _passwordController.text);
                   },
-                  child: Text('Register'),
+                  child: const Text('Register'),
                 )
         ],
       ),

--- a/lib/ui/screens/settings/tools_settings.dart
+++ b/lib/ui/screens/settings/tools_settings.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:tipitaka_pali/ui/screens/dictionary/flashcard_setup_view.dart';
 import 'package:tipitaka_pali/ui/screens/dictionary/text_converter_view.dart';
 import 'package:tipitaka_pali/ui/screens/settings/download_view.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:tipitaka_pali/ui/widgets/colored_text.dart';
 
 class ToolsSettingsView extends StatefulWidget {
@@ -21,7 +21,6 @@ class _ToolsSettingsViewState extends State<ToolsSettingsView> {
   @override
   Widget build(BuildContext context) {
     return Card(
-      elevation: 8,
       child: ExpansionTile(
         key: expansionTileKey, // Assign the key to the ExpansionTile
         leading: const Icon(Icons.build),
@@ -30,7 +29,7 @@ class _ToolsSettingsViewState extends State<ToolsSettingsView> {
         onExpansionChanged: (expanded) {
           if (expanded) {
             // Scroll to the end of the list
-            Future.delayed(Duration(milliseconds: 200)).then((_) {
+            Future.delayed(const Duration(milliseconds: 200)).then((_) {
               RenderObject? renderObject =
                   expansionTileKey.currentContext?.findRenderObject();
               renderObject?.showOnScreen(
@@ -79,7 +78,7 @@ class _ToolsSettingsViewState extends State<ToolsSettingsView> {
     return Padding(
       padding: const EdgeInsets.only(left: 32.0),
       child: ListTile(
-        leading: Icon(Icons.speaker_notes_outlined),
+        leading: const Icon(Icons.speaker_notes_outlined),
         title: ColoredText(AppLocalizations.of(context)!.flashcards),
         focusColor: Theme.of(context).focusColor,
         hoverColor: Theme.of(context).hoverColor,
@@ -87,7 +86,7 @@ class _ToolsSettingsViewState extends State<ToolsSettingsView> {
         onTap: () {
           Navigator.push(
             context,
-            MaterialPageRoute(builder: (context) => FlashCardSetupView()),
+            MaterialPageRoute(builder: (context) => const FlashCardSetupView()),
           );
         },
       ),
@@ -101,7 +100,7 @@ class _ToolsSettingsViewState extends State<ToolsSettingsView> {
         onTap: () {
           Navigator.push(
             context,
-            MaterialPageRoute(builder: (context) => TextConverterView()),
+            MaterialPageRoute(builder: (context) => const TextConverterView()),
           );
         },
         leading: const Icon(Icons.translate),

--- a/lib/ui/screens/splash_screen.dart
+++ b/lib/ui/screens/splash_screen.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:tipitaka_pali/data/constants.dart';
 import 'package:tipitaka_pali/services/get_database_status.dart';
-import 'package:tipitaka_pali/services/prefs.dart';
 
 import 'home/home_container.dart';
 import 'initial_setup.dart';

--- a/lib/ui/widgets/custom_text_selection_control.dart
+++ b/lib/ui/widgets/custom_text_selection_control.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 /// This package allows you to create custom text selection controls and use them in the SelectableText widget or in the TextForm or TextFormField widgets.
 ///

--- a/lib/ui/widgets/select_dictionary_widget.dart
+++ b/lib/ui/widgets/select_dictionary_widget.dart
@@ -35,9 +35,7 @@ class SelectDictionaryWidget extends StatelessWidget {
                   // subtitle: Text('${vm.userDicts[index].userOrder}'),
                   trailing: const Icon(Icons.drag_handle),
                 ),
-                const Divider(
-                  height: 1.0,
-                )
+                if (index < dictionaries.length - 1) const Divider(height: 1.0)
               ],
             );
           },

--- a/packages/slidable_bar/lib/src/slidable_bar_controller.dart
+++ b/packages/slidable_bar/lib/src/slidable_bar_controller.dart
@@ -4,7 +4,8 @@ class SlidableBarController {
   /// the initial bar state when it's build for the first time
   final bool initialStatus;
 
-  SlidableBarController({this.initialStatus = false}) : currentStatus = initialStatus;
+  SlidableBarController({this.initialStatus = false})
+      : currentStatus = initialStatus;
 
   /// return the current state for the bar
   /// open [true], close [false]
@@ -13,7 +14,7 @@ class SlidableBarController {
   /// stream for bar state changes
   Stream<bool> get statusStream => _barStatus.stream;
 
-  StreamController<bool> _barStatus = StreamController<bool>.broadcast();
+  final StreamController<bool> _barStatus = StreamController<bool>.broadcast();
 
   /// to hide the bar
   hide() {

--- a/packages/slidable_bar/lib/src/slidable_bar_widget.dart
+++ b/packages/slidable_bar/lib/src/slidable_bar_widget.dart
@@ -152,9 +152,9 @@ class _SlidableSideBarState extends State<SlidableBar> {
                           decoration: BoxDecoration(
                               color: widget.backgroundColor ??
                                   Theme.of(context).colorScheme.onBackground,
-                              borderRadius: BorderRadius.only(
+                              borderRadius: const BorderRadius.only(
                                   topLeft: Radius.circular(7)),
-                              boxShadow: [
+                              boxShadow: const [
                                 BoxShadow(
                                     color: Colors.black12,
                                     spreadRadius: 1,
@@ -164,7 +164,7 @@ class _SlidableSideBarState extends State<SlidableBar> {
                           child: Container(
                             width: widget.clickerSize * 0.23,
                             height: widget.clickerSize * 0.23,
-                            margin: EdgeInsets.all(6),
+                            margin: const EdgeInsets.all(6),
                             decoration: BoxDecoration(
                                 color: widget.frontColor ??
                                     Theme.of(context).primaryColor,
@@ -264,7 +264,7 @@ class _SideBarContent extends StatelessWidget {
       width: [Side.left, Side.right].contains(side) ? width : null,
       height: [Side.left, Side.right].contains(side) ? null : width,
       decoration: BoxDecoration(
-        boxShadow: [
+        boxShadow: const [
           BoxShadow(color: Colors.black12, spreadRadius: 0, blurRadius: 5),
         ],
         color: backgroundColor ?? Theme.of(context).colorScheme.onBackground,


### PR DESCRIPTION
## Theme proposal and various fixes

Use or abuse the code contributions as you like.

If you want we can do e.g. a video call (if we find a suitable shared time slot) and discuss some of the theme styles proposed here and other changes too. There are so many possibilities and at the end of the day it is just preferences 😄 

The PR contains a commit for each file, so it is easier to see changes per file and a brief comment per file too.

## Material 3 theme mode

This PR adds a M3 based theme proposal and style, with color tints on Cards.

It keeps the old M2 based style available, but modernizes it with FlexColorScheme M3 look alike shapes, but keeps the M2 style AppBar and no color tints.

The style included some Card elevation and color fixes on them, that changes the style a bit.

The TabBar for the reader is now in AppBar when there is AppBar and otherwise outside it.


### Android - Annotated Region - SystemUiOverlayStyle

An attempt to style the system navigation for Android builds was also added. It required some additional configs with SafeArea to make it looks nice. The AnnotatedRegion and SystemUiOverlayStyle settings only impact Android (phone and tablet), but the SafeAreas might needs double checking on all platforms. I might have missed some layouts I did not know about.

![image](https://github.com/bksubhuti/tipitaka-pali-reader/assets/39990307/659988e5-59fb-422c-98d9-d199c02b6e3a)


### Usage of DropdownButton

Consider replacing all usage of DropdownButton, like e.g. lang selection on Settings, with newer widget that supports theming and M3 styling. 

### The bottom bar on the reader

The custom bottom bar on the reader that can slide away, can potentially also be styled a bit more using the active theme's ColorScheme, to make it fit better with the M3 style, when M3 mode is used. I can look at it later if it is of interest.

### Lint and Analyzer Issues

I also fixed a large number of analyzer and lint issues, mostly minor nits.
There are however still 33 warnings and 106 hints that it complains about.

![Screenshot 2023-10-17 at 05 53 01](https://github.com/bksubhuti/tipitaka-pali-reader/assets/39990307/f1a6a3e3-4abb-4352-bf70-43f97588506f)

There are a lot of lint warning about not "Don't use BuildContext across async gaps". The lint is not always bad, but it can cause crashes in some cases. Some can be solved with unawaited(), while other might require StatefulWidget and checking if context is still mounted.

The "Invalid use of a private type in a public API" are generate when using old format of setting up StatefulWidget.

## KNOWN/SEEN BUGS

There are bugs in the navigation. If you use phone and rotate it to landscape and select Setting from rail on the phone in landscape and then rotate phone to portrait the app will crash because it is index 5 (6th one), which does not exist as a selection when rotated back to the bottom NavigationBar.

Other navigation issues seems to be related to used navigation context and animation controller related to animation being disposed. This needs to be studied further.


