### PR TITLE
#300 feat: add autofocus to `TprSearchBar` and enable it in the Sutta…

### DIFF
--- a/lib/ui/dialogs/sutta_list_dialog.dart
+++ b/lib/ui/dialogs/sutta_list_dialog.dart
@@ -182,6 +182,7 @@ class _SuttaListDialogState extends State<SuttaListDialog> {
       children: [
         Expanded(
           child: TprSearchBar(
+            autofocus: true,
             hint: AppLocalizations.of(context)!.nameOrShorthand,
             controller: textEditingController,
             onTextChanged: viewController.onFilterChanged,

--- a/lib/ui/screens/home/widgets/search_bar.dart
+++ b/lib/ui/screens/home/widgets/search_bar.dart
@@ -10,12 +10,14 @@ class TprSearchBar extends StatefulWidget {
   final void Function(String) onSubmitted;
   final void Function(String) onTextChanged;
   final String hint;
+  final bool autofocus;
   const TprSearchBar({
     super.key,
     required this.controller,
     required this.onSubmitted,
     required this.onTextChanged,
     this.hint = 'search',
+    this.autofocus = false,
   });
 
   @override
@@ -46,6 +48,7 @@ class _TprSearchBarState extends State<TprSearchBar> {
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: TextField(
+        autofocus: widget.autofocus,
         autocorrect: false,
         controller: widget.controller,
         textInputAction: TextInputAction.search,


### PR DESCRIPTION
## Description
This PR addresses a usability issue where the search bar in the "Sutta List" dialog did not receive focus automatically upon opening. Users previously had to manually click the search field to begin typing.

## Changes
-   **[lib/ui/screens/home/widgets/search_bar.dart](cci:7://file:///home/bodhirasa/MyFiles/3_Active/tipitaka-pali-reader/lib/ui/screens/home/widgets/search_bar.dart:0:0-0:0)**: Added an `autofocus` parameter to the [TprSearchBar](cci:2://file:///home/bodhirasa/MyFiles/3_Active/tipitaka-pali-reader/lib/ui/screens/home/widgets/search_bar.dart:7:0-24:1) widget (defaulting to `false` to preserve existing behavior elsewhere).
-   **[lib/ui/dialogs/sutta_list_dialog.dart](cci:7://file:///home/bodhirasa/MyFiles/3_Active/tipitaka-pali-reader/lib/ui/dialogs/sutta_list_dialog.dart:0:0-0:0)**: Enabled `autofocus: true` when instantiating the search bar within the Sutta List dialog.

## How Has This Been Tested?
**Manual Verification:**
1.  Launched the app.
2.  Navigated to the Home screen.
3.  Clicked the "Sutta" button.
4.  Verified that the "Sutta List" dialog opens with the cursor immediately active in the search bar and the keyboard ready (on mobile).
5.  Verified that the main Search page still behaves as expected (no forced autofocus).

## Checklist:
-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] My changes generate no new warnings