### PR TITLE
Add deeplink support for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ unlinked_spec.ds
 #appimage related
 TipitakaPaliReader.AppDir
 *.AppImage
+squashfs-root/
 
 # Coverage
 coverage/

--- a/DEEPLINK_LINUX.md
+++ b/DEEPLINK_LINUX.md
@@ -1,0 +1,127 @@
+# Tipitaka Pali Reader - Linux Deeplink Support
+
+## Overview
+The Linux AppImage now supports deeplinks via the `tipitaka://` URL scheme. This allows opening specific suttas directly from web links or terminal commands.
+
+## Usage Methods
+
+### 1. Web Browser Links
+Click on any `tipitaka://` link from websites, documents, or HTML files:
+
+```
+<a href="tipitaka://open?sutta=mn118">MN 118 - Mindfulness of Breathing</a>
+<a href="tipitaka://open?sutta=dn1">DN 1 - Brahma's Net</a>
+<a href="tipitaka://open?sutta=sn56.11">SN 56.11 - The Four Noble Truths</a>
+<a href="tipitaka://open?sutta=an1.1">AN 1.1 - Mindfulness is the Way</a>
+```
+
+### 2. Terminal Commands
+
+#### Direct App Launch with Deeplink
+```bash
+./tipitaka_pali_reader.AppImage "tipitaka://open?sutta=mn118"
+```
+
+#### System URL Handler (xdg-open)
+```bash
+xdg-open "tipitaka://open?sutta=sn56.11"
+```
+
+## URL Format
+
+The deeplink URL format is:
+```
+tipitaka://open?sutta={SUTTA_ID}
+```
+
+### Examples:
+- `tipitaka://open?sutta=mn118` - Opens MN 118 (Ānāpānasati Sutta)
+- `tipitaka://open?sutta=dn1` - Opens DN 1 (Brahmajāla Sutta)
+- `tipitaka://open?sutta=sn56.11` - Opens SN 56.11 (Dhammacakkappavattana Sutta)
+
+## System Integration
+
+### Automatic Installation (from AppImage)
+```bash
+# 1. Extract AppImage to register with system
+./tipitaka_pali_reader.AppImage --appimage-extract
+
+# 2. Install desktop file system-wide
+sudo cp squashfs-root/tipitaka_pali_reader.desktop /usr/share/applications/
+sudo cp squashfs-root/logo.png /usr/share/icons/hicolor/256x256/apps/
+
+# 3. Update desktop database
+sudo update-desktop-database /usr/share/applications
+
+# 4. Set as default URL handler
+xdg-settings set default-url-scheme-handler tipitaka tipitaka_pali_reader.desktop
+```
+
+### User Installation (no sudo required)
+```bash
+# Install for current user only
+mkdir -p ~/.local/share/applications
+cp squashfs-root/tipitaka_pali_reader.desktop ~/.local/share/applications/
+mkdir -p ~/.local/share/icons/hicolor/256x256/apps/
+cp squashfs-root/logo.png ~/.local/share/icons/hicolor/256x256/apps/
+
+# Update databases
+update-desktop-database ~/.local/share/applications
+xdg-settings set default-url-scheme-handler tipitaka tipitaka_pali_reader.desktop
+```
+
+## Testing
+
+### Test with HTML File
+```bash
+# Create test HTML (included in repository)
+xdg-open test_deeplinks.html
+```
+
+### Test from Terminal
+```bash
+# Launch app first
+./tipitaka_pali_reader.AppImage &
+
+# Test with different suttas
+xdg-open "tipitaka://open?sutta=mn118"
+xdg-open "tipitaka://open?sutta=sn56.11"
+```
+
+## Technical Implementation
+
+### What Changed
+
+1. **Desktop File**: Added `MimeType=x-scheme-handler/tipitaka;`
+2. **AppRun Script**: Modified to pass arguments (`"$@"`) to application
+3. **Build Script**: Enhanced to automatically configure deeplink support
+4. **Flutter App**: Added command line argument detection and URL handling
+5. **MIME Registration**: Created `tipitaka.xml` for proper system integration
+
+### Cross-Platform Support
+
+- ✅ **Android**: Intent filter configured in AndroidManifest.xml
+- ✅ **macOS**: URL scheme registered in Info.plist  
+- ✅ **Linux**: MIME type and desktop file configured
+- ✅ **Web Links**: Works from browsers and HTML pages
+
+## Notes
+
+- Links from browsers work correctly and open the specified sutta
+- Multiple app instances may be created (each link click launches new instance)
+- For production use, users should install the desktop file system-wide
+- The deeplink functionality is compatible with all major suttas in the Tipitaka database
+
+## Building
+
+To build with deeplink support:
+
+```bash
+# Build AppImage with automatic deeplink configuration
+./build_appimage2.sh
+```
+
+The build script automatically:
+- Updates desktop file with MIME type
+- Configures AppRun to pass arguments  
+- Creates final AppImage with deeplink support

--- a/TipitakaPaliReader.AppDir/AppRun
+++ b/TipitakaPaliReader.AppDir/AppRun
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd "$(dirname "$0")"
-exec ./tipitaka_pali_reader
+exec ./tipitaka_pali_reader "$@"

--- a/TipitakaPaliReader.AppDir/tipitaka_pali_reader.desktop
+++ b/TipitakaPaliReader.AppDir/tipitaka_pali_reader.desktop
@@ -7,3 +7,4 @@ Exec=tipitaka_pali_reader %u
 Icon=logo
 Categories=Utility;
 StartupWMClass="tipitaka_pali_reader"
+MimeType=x-scheme-handler/tipitaka;

--- a/build_appimage2.sh
+++ b/build_appimage2.sh
@@ -34,8 +34,33 @@ fi
 mkdir -p "$APPDIR"
 cp -r "$BUNDLE_DIR"/. "$APPDIR"/
 
+# Configure deeplink support for Linux
+echo "🔗 Configuring deeplink support..."
+
+# Update desktop file with MIME type for deeplinks
+if [ -f "$APPDIR/tipitaka_pali_reader.desktop" ]; then
+  # Ensure MimeType is present (add if missing)
+  if ! grep -q "MimeType=x-scheme-handler/tipitaka" "$APPDIR/tipitaka_pali_reader.desktop"; then
+    echo "Adding MimeType for deeplink support..."
+    echo "MimeType=x-scheme-handler/tipitaka;" >> "$APPDIR/tipitaka_pali_reader.desktop"
+  fi
+fi
+
+# Update AppRun to pass arguments to the application
+if [ -f "$APPDIR/AppRun" ]; then
+  # Ensure AppRun passes arguments ($@)
+  if ! grep -q "exec.*\$@" "$APPDIR/AppRun"; then
+    echo "Updating AppRun to pass arguments..."
+    cat > "$APPDIR/AppRun" << 'EOF'
+#!/bin/sh
+cd "$(dirname "$0")"
+exec ./tipitaka_pali_reader "$@"
+EOF
+  fi
+  chmod +x "$APPDIR/AppRun"
+fi
+
 # Ensure run permissions for your app launchers (ignore if absent)
-chmod +x "$APPDIR/AppRun" 2>/dev/null || true
 chmod +x "$APPDIR/tipitaka_pali_reader" 2>/dev/null || true
 
 # Build AppImage

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -50,8 +50,9 @@ final Logger myLogger = Logger(
 
 class App extends StatefulWidget {
   final StreamingSharedPreferences rxPref;
+  final String? initialUrl;
 
-  const App({required this.rxPref, super.key});
+  const App({required this.rxPref, this.initialUrl, super.key});
 
   @override
   _AppState createState() => _AppState();
@@ -74,6 +75,14 @@ class _AppState extends State<App> with WindowListener {
       windowManager.addListener(this);
     }
     _initDeepLinks(); // Call the function
+
+    // Handle initial URL from command line (for web links on Linux)
+    if (widget.initialUrl != null &&
+        widget.initialUrl!.startsWith('tipitaka://')) {
+      Future.delayed(const Duration(milliseconds: 500), () {
+        _handleLink(Uri.parse(widget.initialUrl!));
+      });
+    }
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,12 +7,26 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:devicelocale/devicelocale.dart';
 
 import 'dart:io' show Platform;
+import 'dart:io' show Platform;
 
 import 'package:tipitaka_pali/services/setup_firestore.dart';
 import 'package:tipitaka_pali/utils/platform_info.dart';
 import 'package:window_manager/window_manager.dart';
 
-void main() async {
+// Global variable to store URL from command line
+String? _initialUrl;
+
+void main(List<String> args) async {
+  // Check for URL in command line arguments
+  if (Platform.isLinux || Platform.isWindows) {
+    for (final arg in args) {
+      if (arg.startsWith('tipitaka://')) {
+        _initialUrl = arg;
+        break;
+      }
+    }
+  }
+
   if (Platform.isWindows || Platform.isLinux) {
     // Initialize FFI
     sqfliteFfiInit();
@@ -71,7 +85,7 @@ void main() async {
     Prefs.selectedSubCategoryFilters = defultSelectedSubCategoryFilters;
   }
 
-  runApp(App(rxPref: rxPref));
+  runApp(App(rxPref: rxPref, initialUrl: _initialUrl));
 }
 
 setScriptAndLanguageByLocal() async {

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,13 +7,25 @@
 #include "generated_plugin_registrant.h"
 
 #include <devicelocale/devicelocale_plugin.h>
+#include <gtk/gtk_plugin.h>
+#include <screen_retriever_linux/screen_retriever_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
+#include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) devicelocale_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DevicelocalePlugin");
   devicelocale_plugin_register_with_registrar(devicelocale_registrar);
+  g_autoptr(FlPluginRegistrar) gtk_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
+  gtk_plugin_register_with_registrar(gtk_registrar);
+  g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
+  screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
+  g_autoptr(FlPluginRegistrar) window_manager_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
+  window_manager_plugin_register_with_registrar(window_manager_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,7 +4,10 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   devicelocale
+  gtk
+  screen_retriever_linux
   url_launcher_linux
+  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,26 +5,32 @@
 import FlutterMacOS
 import Foundation
 
+import app_links
 import connectivity_plus
 import devicelocale
 import file_picker
 import in_app_review
 import package_info_plus
 import path_provider_foundation
+import screen_retriever_macos
 import share_plus
 import shared_preferences_foundation
 import sqflite_darwin
 import url_launcher_macos
+import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DevicelocalePlugin.register(with: registry.registrar(forPlugin: "DevicelocalePlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   InAppReviewPlugin.register(with: registry.registrar(forPlugin: "InAppReviewPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
+  WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/test_deeplinks.html
+++ b/test_deeplinks.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test Tipitaka Deeplinks</title>
+</head>
+<body>
+    <h1>Tipitaka Pali Reader Deeplink Test</h1>
+    
+    <h2>Test these links:</h2>
+    
+    <ul>
+        <li><a href="tipitaka://open?sutta=mn118">MN 118 - Mindfulness of Breathing</a></li>
+        <li><a href="tipitaka://open?sutta=dn1">DN 1 - Brahma's Net</a></li>
+        <li><a href="tipitaka://open?sutta=sn56.11">SN 56.11 - The Four Noble Truths</a></li>
+        <li><a href="tipitaka://open?sutta=an1.1">AN 1.1 - Mindfulness is the Way</a></li>
+    </ul>
+    
+    <h2>Instructions:</h2>
+    <ol>
+        <li>Make sure Tipitaka Pali Reader AppImage is running</li>
+        <li>Click on any link above</li>
+        <li>The sutta should open directly in the running app</li>
+    </ol>
+</body>
+</html>

--- a/tipitaka.xml
+++ b/tipitaka.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+  <mime-type type="x-scheme-handler/tipitaka">
+    <comment>Tipitaka URL Scheme</comment>
+    <icon name="tipitaka_pali_reader"/>
+  </mime-type>
+</mime-info>

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,18 +6,30 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <app_links/app_links_plugin_c_api.h>
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
+#include <msix/none.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
+#include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
+#include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  AppLinksPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
+  noneRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("none"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
+  ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
+  WindowManagerPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("WindowManagerPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,10 +3,14 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  app_links
   connectivity_plus
+  msix
   permission_handler_windows
+  screen_retriever_windows
   share_plus
   url_launcher_windows
+  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
This commit introduces the necessary changes to support 'tipitaka://' deep links on Linux:
- Updated .desktop file with MimeType handling.
- Modified AppRun to pass command line arguments to the executable.
- Enhanced build_appimage2.sh to automate these configurations.
- Added command-line argument processing in main.dart and App widget to handle deep links on startup.
- Included DEEPLINK_LINUX.md documentation and a test HTML file.
- Added tipitaka.xml for system MIME registration.